### PR TITLE
Added awaitEvent() & getFriendStatus() + Temp fix for missing INITITAL_INVITE

### DIFF
--- a/src/Collector.js
+++ b/src/Collector.js
@@ -1,4 +1,4 @@
-const EventEmitter = require('events').EventEmitter;
+const EventEmitter = require('events');
 
 class Collector extends EventEmitter {
   constructor(communicator, fnEvent, filter, time) {

--- a/src/Collector.js
+++ b/src/Collector.js
@@ -10,9 +10,6 @@ class Collector extends EventEmitter {
 
     this.handle = this.handle.bind(this);
     this.communicator.addListener(this.fnEvent, this.handle);
-    // this.communicator.addListener(this.fnEvent, m => {
-    //   console.log("testing")
-    // });
     if(this.time) this.timeout = setTimeout(() => this.stop("TIMEOUT"), this.time);
   };
 

--- a/src/Collector.js
+++ b/src/Collector.js
@@ -1,0 +1,31 @@
+const EventEmitter = require('events').EventEmitter;
+
+class Collector extends EventEmitter {
+  constructor(communicator, fnEvent, filter, time) {
+    super();
+    this.communicator = communicator;
+    this.fnEvent = fnEvent;
+    this.filter = filter;
+    this.time = time;
+
+    this.handle = this.handle.bind(this);
+    this.communicator.addListener(this.fnEvent, this.handle);
+    // this.communicator.addListener(this.fnEvent, m => {
+    //   console.log("testing")
+    // });
+    if(this.time) this.timeout = setTimeout(() => this.stop("TIMEOUT"), this.time);
+  };
+
+  handle(...args) {
+    if(this.filter && !this.filter(...args)) return;
+    this.stop("SUCCESS", args)
+  };
+
+  stop(reason, args) {
+    if(this.time) clearTimeout(this.timeout);
+    this.communicator.removeListener(this.fnEvent, this.handle);
+    this.emit("collect", reason, args);
+  };
+};
+
+module.exports = Collector;

--- a/src/Communicator/index.js
+++ b/src/Communicator/index.js
@@ -38,6 +38,30 @@ class Communicator extends EventEmitter {
   makeJID(...args) {
     return new JID(...args);
   }
+  
+  makeInvFromStatus(status) {
+    const propertyKeys = Object.keys(status.properties);
+    if (propertyKeys.length === 0) return null;
+    const joinInfoKey = propertyKeys.find(key => /^party\.joininfodata\.([0-9]{0,})_j$/.test(key));
+    const joinInfoData = status.properties[joinInfoKey];
+
+    let invitation = {
+      party_id: joinInfoData['partyId'],
+      sent_by: status.sender.id,
+      meta:
+      { 'urn:epic:conn:type_s': 'game',
+        'urn:epic:conn:platform_s': joinInfoData['sourcePlatform'],
+        'urn:epic:member:dn_s': joinInfoData['sourceDisplayName'],
+        'urn:epic:cfg:build-id_s': joinInfoData['buildId'],
+        'urn:epic:invite:platformdata_s': '' },
+      sent_to: this.launcher.account.id,
+      sent_at: new Date(Date.now()).toISOString(),
+      updated_at: new Date(Date.now()).toISOString(),
+      expires_at: new Date(Date.now()).setHours(4),
+      status: 'SENT'
+    }
+    return invitation;
+  }
 
   connect(authToken) {
     return new Promise((resolve) => {
@@ -222,10 +246,14 @@ class Communicator extends EventEmitter {
             );
             
             let invitation = data.invites.find(invite => invite.sent_by === body.pinger_id && invite.status === 'SENT');
-
             if (!invitation) {
-              this.launcher.debug.print('Fortnite: Cannot join into the party. Reason: No active invitation');
-              break;
+              let status = await this.getStatus(body.pinger_id);
+              invitation = this.makeInvFromStatus(status);
+
+              if(!invitation) {
+                this.launcher.debug.print('Fortnite: Cannot join into the party. Reason: No active invitation');
+                break;
+              }
             }
 
             if (
@@ -548,6 +576,27 @@ class Communicator extends EventEmitter {
       type: 'probe',
     });
 
+  }
+  
+  awaitEvent(fnEvent, filter, time) {
+    return new Promise((resolve, reject) => {
+      let collector = new Collector(this, fnEvent, filter, time);
+      collector.once("collect", (reason, args) => {
+        if (reason === "SUCCESS") resolve(...args);
+        reject(reason);
+      });
+    });
+  }
+
+  async getStatus(id) {
+    await this.sendProbe(`${id}@${this.host}`);
+
+    try {
+      return await this.awaitEvent('friend:status', s => s.sender.id === id && s.status, 5 * 1000);
+    } catch(err) {
+      if(err === "TIMEOUT")
+        throw 'Could not retrieve status';
+    }
   }
 
 }

--- a/src/Communicator/index.js
+++ b/src/Communicator/index.js
@@ -252,7 +252,7 @@ class Communicator extends EventEmitter {
             
             let invitation = data.invites.find(invite => invite.sent_by === body.pinger_id && invite.status === 'SENT');
             if (!invitation) {
-              let status = await this.getStatus(body.pinger_id);
+              let status = await this.getFriendStatus(body.pinger_id);
               invitation = this.makeInvFromStatus(status);
 
               if(!invitation) {
@@ -593,7 +593,7 @@ class Communicator extends EventEmitter {
     });
   }
 
-  async getStatus(id) {
+  async getFriendStatus(id) {
     await this.sendProbe(`${id}@${this.host}`);
 
     try {

--- a/src/Communicator/index.js
+++ b/src/Communicator/index.js
@@ -45,6 +45,10 @@ class Communicator extends EventEmitter {
     if (propertyKeys.length === 0) return null;
     const joinInfoKey = propertyKeys.find(key => /^party\.joininfodata\.([0-9]{0,})_j$/.test(key));
     const joinInfoData = status.properties[joinInfoKey];
+    
+    let now = new Date(Date.now());
+    let expiresAt = new Date(Date.now());
+    expiresAt.setHours(4);
 
     let invitation = {
       party_id: joinInfoData['partyId'],
@@ -56,9 +60,9 @@ class Communicator extends EventEmitter {
         'urn:epic:cfg:build-id_s': joinInfoData['buildId'],
         'urn:epic:invite:platformdata_s': '' },
       sent_to: this.launcher.account.id,
-      sent_at: new Date(Date.now()).toISOString(),
-      updated_at: new Date(Date.now()).toISOString(),
-      expires_at: new Date(Date.now()).setHours(4),
+      sent_at: now.toISOString(),
+      updated_at: now.toISOString(),
+      expires_at: expiresAt.toISOString(),
       status: 'SENT'
     }
     return invitation;

--- a/src/Communicator/index.js
+++ b/src/Communicator/index.js
@@ -46,18 +46,20 @@ class Communicator extends EventEmitter {
     const joinInfoKey = propertyKeys.find(key => /^party\.joininfodata\.([0-9]{0,})_j$/.test(key));
     const joinInfoData = status.properties[joinInfoKey];
     
+    if(joinInfoData.bInPrivate) return;
+    
     let now = new Date(Date.now());
     let expiresAt = new Date(Date.now());
     expiresAt.setHours(4);
 
     let invitation = {
-      party_id: joinInfoData['partyId'],
+      party_id: joinInfoData.partyId,
       sent_by: status.sender.id,
       meta:
       { 'urn:epic:conn:type_s': 'game',
-        'urn:epic:conn:platform_s': joinInfoData['sourcePlatform'],
-        'urn:epic:member:dn_s': joinInfoData['sourceDisplayName'],
-        'urn:epic:cfg:build-id_s': joinInfoData['buildId'],
+        'urn:epic:conn:platform_s': joinInfoData.sourcePlatform,
+        'urn:epic:member:dn_s': joinInfoData.sourceDisplayName,
+        'urn:epic:cfg:build-id_s': joinInfoData.buildId,
         'urn:epic:invite:platformdata_s': '' },
       sent_to: this.launcher.account.id,
       sent_at: now.toISOString(),

--- a/src/Communicator/index.js
+++ b/src/Communicator/index.js
@@ -5,6 +5,7 @@ const UUID = require('uuid/v4');
 const EUserState = require('../../enums/UserState');
 
 const Status = require('./Status');
+const Collector = require('../Collector');
 const Friend = require('../Friend');
 const FriendRequest = require('../FriendRequest');
 const FriendMessage = require('./FriendMessage');


### PR DESCRIPTION
+ `communicator.awaitEvent(event, filter, time)`
```js
// awaitEvent(event, filter, time)
// event = communicator events
// filter = function that returns bool
// time = Milliseconds before auto-shutdown and error 'TIMEOUT' is raised

const filter = m => m.friend.id === 'fortniteId';
try {
  let message = await app.communicator.awaitEvent('friend:message', filter, 60 * 1000);
  console.log(message.message);
} catch(err) {
  console.log(err)
}
```


+ `communicator.getFriendStatus(id)`
```js
let status = await app.communicator.getFriendStatus(id);
```

+ Temporary fix for missing INITAL_INVITE.
This works by creating an invite from status properties
